### PR TITLE
Fix packaging to wheel/sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include payton/scene/gui/monofonto.ttf
 include payton/scene/particle.png
+include payton/scene/font/Glametrix.otf

--- a/payton/scene/MANIFEST.in
+++ b/payton/scene/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include payton/ *

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,9 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
-package_dir =
-    = payton
 packages = find:
 python_requires = >=3.8
+include_package_data = True
 install_requires =
     Pillow >=9.0.1
     PyOpenGL >=3.1.6
@@ -24,9 +23,6 @@ install_requires =
     PySDL2 >=0.9.11
     Cython >=0.29.28
     numpy >=1.22.3
-
-[options.packages.find]
-where = payton
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
The wheels currently on PyPI are invalid. Rather than containing a single `payton` package with subpackages `payton.math`, `payton.scene` and `pyaton.tools` the user gets `math`, `scene` and `tools` as standalone packages which can't find each other.

This fixes the above and also fixes collection of some data files that were otherwise being left behind.
