### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   analyze:
     name: Analyze
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/sinanislekdemir/payton/security/code-scanning/6](https://github.com/sinanislekdemir/payton/security/code-scanning/6)

To fix the problem, add a `permissions` block to the workflow to explicitly restrict the `GITHUB_TOKEN` permissions to the minimum required. For a CodeQL analysis workflow, this is typically `contents: read`. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). Since there is only one job in this workflow, either approach is acceptable, but adding it at the job level is more targeted and aligns with the CodeQL recommendation. The change should be made by inserting the following lines under the `analyze` job definition (after line 14):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Restrict GITHUB_TOKEN permissions in the CodeQL analysis workflow to contents: read