### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Payton package
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/sinanislekdemir/payton/security/code-scanning/4](https://github.com/sinanislekdemir/payton/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs local checks, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` and before the `on` key. This will apply the restriction to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add permissions: contents: read to the pythonpackage workflow