### PR TITLE
1.4.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ lint:
 	@ruff check payton
 
 fmt:
-	isort .
 	ruff check payton --fix
 	ruff format payton
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ You can either download the whole repository [as a zip file](https://github.com/
   * Multiplayer
     * [Server backend for a multiplayer game](https://github.com/sinanislekdemir/payton/blob/master/examples/high-level/multiplayer/server.py)
     * [3D Blocks building game multiplayer](https://github.com/sinanislekdemir/payton/blob/master/examples/high-level/multiplayer/client3D.py)
+  * [3D object designer tool](https://github.com/sinanislekdemir/payton/blob/master/examples/designer/main.py)
 
 ## Contribution
 

--- a/examples/basics/40_minecraft_like.py
+++ b/examples/basics/40_minecraft_like.py
@@ -1,11 +1,14 @@
 import math
 import random
+
 import sdl2
+
+from payton.math.functions import distance
 from payton.scene import Scene
+from payton.scene.controller import Controller
 from payton.scene.geometry import Cube
 from payton.scene.gui import info_box
-from payton.scene.controller import Controller
-from payton.math.functions import distance
+
 
 class MinecraftApp(Scene):
     def __init__(self, **kwargs):

--- a/examples/designer/README.md
+++ b/examples/designer/README.md
@@ -1,0 +1,89 @@
+# Payton Designer Example
+
+This example is a lightweight 3D object designer built with Payton.
+
+It lets you:
+
+- add primitive objects
+- select objects in the scene
+- edit position, rotation, scale, and color
+- save the scene as JSON
+- export the current scene as Wavefront OBJ
+
+## Run
+
+From the repository root:
+
+```bash
+python examples/designer/main.py
+```
+
+If you are setting up the repository locally first, install the dependencies from the project root:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Controls
+
+### Mouse
+
+- **Left click object**: select object
+- **Right mouse drag**: rotate camera
+- **Middle mouse drag**: pan camera
+- **Mouse wheel**: zoom
+
+### Keyboard
+
+- **1**: add cube
+- **2**: add sphere
+- **3**: add cylinder
+- **4**: add plane
+- **Delete / Backspace**: delete selected object
+- **Ctrl+S**: save scene JSON
+- **Ctrl+L**: load scene JSON
+- **Ctrl+E**: export OBJ
+
+Payton scene defaults are also available, including:
+
+- **G**: show/hide grid
+- **W**: change display mode
+- **C**: toggle camera projection
+- **H**: show/hide help
+- **Escape**: quit
+
+## UI workflow
+
+The left panel is for scene actions:
+
+- add primitives
+- save/load the scene
+- export OBJ
+- view the current status message
+
+The right panel is for the selected object:
+
+- selected object name
+- primitive type
+- position
+- rotation in degrees
+- scale
+- color as RGB values in the `0.0` to `1.0` range
+
+To edit a value, click the field, type a new comma-separated triple, and press **Enter**.
+
+Examples:
+
+- Position: `1.0, 2.0, 0.5`
+- Rotation: `0.0, 45.0, 90.0`
+- Scale: `1.0, 1.0, 1.0`
+- Color: `0.4, 0.7, 1.0`
+
+## Files
+
+By default, the example uses these filenames from the current working directory:
+
+- scene save: `designer_scene.json`
+- OBJ export: `designer_export.obj`
+
+You can change both filenames from the left panel before saving or exporting.

--- a/examples/designer/app.py
+++ b/examples/designer/app.py
@@ -1,0 +1,401 @@
+import json
+import math
+from copy import deepcopy
+from pathlib import Path
+
+import sdl2
+
+from payton.math.functions import distance
+from payton.math.matrix import IDENTITY_MATRIX
+from payton.scene import Scene, THEME_STUDIO
+from payton.scene.controller import BaseController
+from payton.scene.geometry import Cube, Cylinder, Plane, Sphere
+
+from designer_io import export_scene, load_scene, save_scene
+from ui import build_designer_ui
+
+
+PRIMITIVE_DEFAULTS = {
+    "cube": {
+        "kind": "cube",
+        "params": {"width": 1.0, "depth": 1.0, "height": 1.0},
+        "position": [0.0, 0.0, 0.5],
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [1.0, 1.0, 1.0],
+        "color": [0.4, 0.7, 1.0],
+    },
+    "sphere": {
+        "kind": "sphere",
+        "params": {"radius": 0.5, "parallels": 12, "meridians": 12},
+        "position": [0.0, 0.0, 0.5],
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [1.0, 1.0, 1.0],
+        "color": [1.0, 0.6, 0.3],
+    },
+    "cylinder": {
+        "kind": "cylinder",
+        "params": {"bottom_radius": 0.5, "top_radius": 0.5, "height": 1.0, "meridians": 16},
+        "position": [0.0, 0.0, 0.5],
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [1.0, 1.0, 1.0],
+        "color": [0.5, 0.9, 0.5],
+    },
+    "plane": {
+        "kind": "plane",
+        "params": {"width": 1.5, "height": 1.5},
+        "position": [0.0, 0.0, 0.02],
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [1.0, 1.0, 1.0],
+        "color": [0.9, 0.9, 0.9],
+    },
+}
+
+
+class DesignerController(BaseController):
+    def keyboard(self, event, scene):
+        if event.type != sdl2.SDL_KEYUP:
+            return False
+
+        key = event.key.keysym.sym
+        if key == sdl2.SDLK_1:
+            scene.add_cube()
+            return True
+        if key == sdl2.SDLK_2:
+            scene.add_sphere()
+            return True
+        if key == sdl2.SDLK_3:
+            scene.add_cylinder()
+            return True
+        if key == sdl2.SDLK_4:
+            scene.add_plane()
+            return True
+        if key in [sdl2.SDLK_DELETE, sdl2.SDLK_BACKSPACE]:
+            scene.delete_selected()
+            return True
+        if scene._ctrl_down and key == sdl2.SDLK_s:
+            scene.save_scene_file()
+            return True
+        if scene._ctrl_down and key == sdl2.SDLK_l:
+            scene.load_scene_file()
+            return True
+        if scene._ctrl_down and key == sdl2.SDLK_e:
+            scene.export_scene_file()
+            return True
+        return False
+
+    def mouse(self, event, scene):
+        return False
+
+
+class DesignerScene(Scene):
+    def __init__(self):
+        super().__init__(width=1440, height=900, on_select=self.select_from_hits, theme=THEME_STUDIO)
+        self.grid.visible = True
+        self.active_camera.position = [8.0, -10.0, 8.0]
+        self.active_camera.target = [0.0, 0.0, 1.0]
+
+        self.design_specs = {}
+        self.primitive_counts = {name: 0 for name in PRIMITIVE_DEFAULTS}
+        self.selected_name = None
+
+        self.controller.add_controller(DesignerController())
+        self.hud, self.widgets = build_designer_ui(self)
+        self.add_object("designer_ui", self.hud)
+        self.set_status("Ready")
+        self.update_inspector()
+
+    def add_cube(self):
+        self.add_primitive("cube")
+
+    def add_sphere(self):
+        self.add_primitive("sphere")
+
+    def add_cylinder(self):
+        self.add_primitive("cylinder")
+
+    def add_plane(self):
+        self.add_primitive("plane")
+
+    def set_status(self, message):
+        if len(message) > 30:
+            message = message[:27] + "..."
+        self.widgets["status"].label = message
+
+    def _next_name(self, kind):
+        index = self.primitive_counts[kind]
+        while f"{kind}_{index}" in self.design_specs:
+            index += 1
+        self.primitive_counts[kind] = index + 1
+        return f"{kind}_{index}"
+
+    def _spawn_position(self, kind):
+        if self.selected_name in self.design_specs:
+            current = self.design_specs[self.selected_name]["position"]
+            z = current[2]
+            if kind == "plane":
+                z = 0.02
+            return [current[0] + 1.75, current[1], z]
+
+        count = len(self.design_specs)
+        col = count % 4
+        row = count // 4
+        z = 0.5 if kind != "plane" else 0.02
+        return [-3.0 + (col * 2.0), -3.0 + (row * 2.0), z]
+
+    def _apply_spec_transform(self, obj, spec):
+        obj.matrix = deepcopy(IDENTITY_MATRIX)
+        obj.scale(*spec["scale"])
+        obj.rotate_around_x(math.radians(spec["rotation"][0]))
+        obj.rotate_around_y(math.radians(spec["rotation"][1]))
+        obj.rotate_around_z(math.radians(spec["rotation"][2]))
+        obj.position = list(spec["position"])
+        obj.material.color = list(spec["color"])
+
+    def _build_object(self, spec):
+        kind = spec["kind"]
+        params = dict(spec["params"])
+        if kind == "cube":
+            obj = Cube(**params)
+        elif kind == "sphere":
+            obj = Sphere(**params)
+        elif kind == "cylinder":
+            obj = Cylinder(**params)
+        elif kind == "plane":
+            obj = Plane(**params)
+        else:
+            raise ValueError(f"Unsupported primitive type: {kind}")
+
+        self._apply_spec_transform(obj, spec)
+        return obj
+
+    def _store_object(self, name, spec):
+        self.design_specs[name] = deepcopy(spec)
+        obj = self._build_object(spec)
+        self.add_object(name, obj)
+
+    def add_primitive(self, kind):
+        spec = deepcopy(PRIMITIVE_DEFAULTS[kind])
+        spec["position"] = self._spawn_position(kind)
+        name = self._next_name(kind)
+        self._store_object(name, spec)
+        self.select_object(name)
+        self.set_status(f"Created {name}")
+
+    def _refresh_selection_visuals(self):
+        for name, spec in self.design_specs.items():
+            obj = self.objects.get(name)
+            if obj is None:
+                continue
+            color = list(spec["color"])
+            if name == self.selected_name:
+                color = [1.0, 0.85, 0.2]
+            obj.material.color = color
+
+    def select_from_hits(self, hits):
+        candidates = [obj for obj in hits if obj.name in self.design_specs]
+        if not candidates:
+            return
+
+        nearest = min(
+            candidates,
+            key=lambda obj: distance(obj.position, self.active_camera.position),
+        )
+        self.select_object(nearest.name)
+
+    def select_object(self, name):
+        if name not in self.design_specs:
+            self.clear_selection()
+            return
+        self.selected_name = name
+        self._refresh_selection_visuals()
+        self.update_inspector()
+        self.set_status(f"Selected {name}")
+
+    def clear_selection(self):
+        self.selected_name = None
+        self._refresh_selection_visuals()
+        self.update_inspector()
+        self.set_status("Selection cleared")
+
+    def delete_selected(self):
+        if self.selected_name is None:
+            self.set_status("Nothing is selected.")
+            return
+
+        name = self.selected_name
+        if name in self.objects:
+            del self.objects[name]
+        if name in self.design_specs:
+            del self.design_specs[name]
+        self.selected_name = None
+        self._refresh_selection_visuals()
+        self.update_inspector()
+        self.set_status(f"Deleted {name}")
+
+    def _selected_spec(self):
+        if self.selected_name is None:
+            self.set_status("Select an object first.")
+            return None
+        return self.design_specs[self.selected_name]
+
+    def _parse_vector(self, text, label):
+        parts = [part.strip() for part in text.split(",")]
+        if len(parts) != 3:
+            raise ValueError(f"{label} must contain exactly three comma-separated numbers.")
+        return [float(part) for part in parts]
+
+    def _apply_selected_spec(self):
+        spec = self._selected_spec()
+        if spec is None:
+            self.update_inspector()
+            return
+        self._apply_spec_transform(self.objects[self.selected_name], spec)
+        self._refresh_selection_visuals()
+        self.update_inspector()
+
+    def set_position_text(self, text):
+        spec = self._selected_spec()
+        if spec is None:
+            return
+        try:
+            spec["position"] = self._parse_vector(text, "Position")
+        except ValueError as exc:
+            self.set_status(str(exc))
+            self.update_inspector()
+            return
+        self._apply_selected_spec()
+        self.set_status(f"Updated position for {self.selected_name}")
+
+    def set_rotation_text(self, text):
+        spec = self._selected_spec()
+        if spec is None:
+            return
+        try:
+            spec["rotation"] = self._parse_vector(text, "Rotation")
+        except ValueError as exc:
+            self.set_status(str(exc))
+            self.update_inspector()
+            return
+        self._apply_selected_spec()
+        self.set_status(f"Updated rotation for {self.selected_name}")
+
+    def set_scale_text(self, text):
+        spec = self._selected_spec()
+        if spec is None:
+            return
+        try:
+            scale = self._parse_vector(text, "Scale")
+        except ValueError as exc:
+            self.set_status(str(exc))
+            self.update_inspector()
+            return
+
+        if any(value <= 0 for value in scale):
+            self.set_status("Scale values must all be greater than zero.")
+            self.update_inspector()
+            return
+
+        spec["scale"] = scale
+        self._apply_selected_spec()
+        self.set_status(f"Updated scale for {self.selected_name}")
+
+    def set_color_text(self, text):
+        spec = self._selected_spec()
+        if spec is None:
+            return
+        try:
+            color = self._parse_vector(text, "Color")
+        except ValueError as exc:
+            self.set_status(str(exc))
+            self.update_inspector()
+            return
+
+        if any(value < 0 or value > 1 for value in color):
+            self.set_status("Color channels must stay between 0.0 and 1.0.")
+            self.update_inspector()
+            return
+
+        spec["color"] = color
+        self._apply_selected_spec()
+        self.set_status(f"Updated color for {self.selected_name}")
+
+    def _format_vector(self, values):
+        return ", ".join(f"{value:.3f}" for value in values)
+
+    def update_inspector(self):
+        if self.selected_name is None:
+            self.widgets["selected_name"].label = "None"
+            self.widgets["selected_type"].label = "-"
+            self.widgets["position"].value = "0.000, 0.000, 0.500"
+            self.widgets["rotation"].value = "0.000, 0.000, 0.000"
+            self.widgets["scale"].value = "1.000, 1.000, 1.000"
+            self.widgets["color"].value = "0.400, 0.700, 1.000"
+            return
+
+        spec = self.design_specs[self.selected_name]
+        self.widgets["selected_name"].label = self.selected_name
+        self.widgets["selected_type"].label = spec["kind"]
+        self.widgets["position"].value = self._format_vector(spec["position"])
+        self.widgets["rotation"].value = self._format_vector(spec["rotation"])
+        self.widgets["scale"].value = self._format_vector(spec["scale"])
+        self.widgets["color"].value = self._format_vector(spec["color"])
+
+    def _scene_filename(self):
+        return self.widgets["scene_file"].value.strip()
+
+    def _export_filename(self):
+        return self.widgets["export_file"].value.strip()
+
+    def save_scene_file(self):
+        try:
+            path = save_scene(self.design_specs, self._scene_filename())
+        except OSError as exc:
+            self.set_status(f"Save failed: {exc}")
+            return
+        self.set_status(f"Saved {Path(path).name}")
+
+    def _clear_objects(self):
+        for name in list(self.design_specs):
+            if name in self.objects:
+                del self.objects[name]
+        self.design_specs = {}
+        self.selected_name = None
+
+    def _rebuild_counts(self):
+        self.primitive_counts = {name: 0 for name in PRIMITIVE_DEFAULTS}
+        for name, spec in self.design_specs.items():
+            kind = spec["kind"]
+            prefix = f"{kind}_"
+            if name.startswith(prefix):
+                suffix = name[len(prefix) :]
+                if suffix.isdigit():
+                    self.primitive_counts[kind] = max(self.primitive_counts[kind], int(suffix) + 1)
+                    continue
+            self.primitive_counts[kind] += 1
+
+    def load_scene_file(self):
+        try:
+            path, objects = load_scene(self._scene_filename())
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            self.set_status(f"Load failed: {exc}")
+            return
+
+        self._clear_objects()
+        for name, spec in objects.items():
+            self._store_object(name, spec)
+        self._rebuild_counts()
+        self._refresh_selection_visuals()
+        self.update_inspector()
+        self.set_status(f"Loaded {Path(path).name}")
+
+    def export_scene_file(self):
+        meshes = []
+        for spec in self.design_specs.values():
+            meshes.append(self._build_object(spec))
+
+        try:
+            path = export_scene(meshes, self._export_filename())
+        except (OSError, ValueError) as exc:
+            self.set_status(f"Export failed: {exc}")
+            return
+        self.set_status(f"Exported {Path(path).name}")

--- a/examples/designer/designer_io.py
+++ b/examples/designer/designer_io.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+from payton.scene.geometry.wavefront import export as export_wavefront
+from payton.tools.mesh.geometry import merge_mesh
+
+DEFAULT_SCENE_FILE = "designer_scene.json"
+DEFAULT_EXPORT_FILE = "designer_export.obj"
+
+
+def save_scene(specs, filename):
+    path = Path(filename).expanduser()
+    path.write_text(json.dumps({"objects": specs}, indent=2))
+    return path
+
+
+def load_scene(filename):
+    path = Path(filename).expanduser()
+    data = json.loads(path.read_text())
+    objects = data.get("objects")
+    if not isinstance(objects, dict):
+        raise ValueError("Scene file must contain an 'objects' dictionary.")
+    return path, objects
+
+
+def export_scene(meshes, filename):
+    if not meshes:
+        raise ValueError("There are no objects to export.")
+
+    merged = meshes[0]
+    for mesh in meshes[1:]:
+        merged = merge_mesh(merged, mesh)
+    merged.fix_normals()
+
+    path = Path(filename).expanduser()
+    export_wavefront(merged, str(path))
+    return path

--- a/examples/designer/main.py
+++ b/examples/designer/main.py
@@ -1,0 +1,6 @@
+from app import DesignerScene
+
+
+if __name__ == "__main__":
+    scene = DesignerScene()
+    scene.run()

--- a/examples/designer/ui.py
+++ b/examples/designer/ui.py
@@ -1,0 +1,216 @@
+from payton.scene.gui import Button, EditBox, Hud, Window, WindowAlignment
+
+from designer_io import DEFAULT_EXPORT_FILE, DEFAULT_SCENE_FILE
+
+
+def build_designer_ui(scene):
+    hud = Hud()
+    widgets = {}
+
+    actions = Window(
+        "Designer",
+        width=280,
+        height=900,
+        align=WindowAlignment.LEFT,
+        theme=scene.ui_theme,
+    )
+    widgets["actions_window"] = actions
+
+    top = 40
+    step = 40
+    button_width = 250
+
+    buttons = [
+        ("add_cube", "Add Cube", scene.add_cube),
+        ("add_sphere", "Add Sphere", scene.add_sphere),
+        ("add_cylinder", "Add Cylinder", scene.add_cylinder),
+        ("add_plane", "Add Plane", scene.add_plane),
+        ("clear_selection", "Clear Selection", scene.clear_selection),
+        ("delete_selected", "Delete Selected", scene.delete_selected),
+    ]
+
+    for name, label, callback in buttons:
+        actions.add_child(
+            name,
+            Button(
+                label,
+                width=button_width,
+                height=30,
+                left=15,
+                top=top,
+                on_click=callback,
+            ),
+        )
+        top += step
+
+    actions.add_child(
+        "scene_file_label",
+        Button("Scene File", width=button_width, height=30, left=15, top=top),
+    )
+    top += step
+    widgets["scene_file"] = EditBox(
+        DEFAULT_SCENE_FILE,
+        width=button_width,
+        height=30,
+        left=15,
+        top=top,
+    )
+    actions.add_child("scene_file", widgets["scene_file"])
+    top += step
+
+    actions.add_child(
+        "save_scene",
+        Button("Save Scene", width=button_width, height=30, left=15, top=top, on_click=scene.save_scene_file),
+    )
+    top += step
+    actions.add_child(
+        "load_scene",
+        Button("Load Scene", width=button_width, height=30, left=15, top=top, on_click=scene.load_scene_file),
+    )
+    top += step
+
+    actions.add_child(
+        "export_file_label",
+        Button("OBJ Export File", width=button_width, height=30, left=15, top=top),
+    )
+    top += step
+    widgets["export_file"] = EditBox(
+        DEFAULT_EXPORT_FILE,
+        width=button_width,
+        height=30,
+        left=15,
+        top=top,
+    )
+    actions.add_child("export_file", widgets["export_file"])
+    top += step
+    actions.add_child(
+        "export_scene",
+        Button("Export OBJ", width=button_width, height=30, left=15, top=top, on_click=scene.export_scene_file),
+    )
+    top += step
+
+    actions.add_child(
+        "status_label",
+        Button("Status", width=button_width, height=30, left=15, top=top),
+    )
+    top += step
+    widgets["status"] = Button(
+        "Ready",
+        width=button_width,
+        height=30,
+        left=15,
+        top=top,
+    )
+    actions.add_child("status", widgets["status"])
+    top += step
+
+    shortcut_lines = [
+        ("shortcuts_1", "1-4 Add  |  Del Delete"),
+        ("shortcuts_2", "Ctrl+S Save  |  Ctrl+L Load"),
+        ("shortcuts_3", "Ctrl+E Export OBJ"),
+    ]
+    for name, label in shortcut_lines:
+        widgets[name] = Button(
+            label,
+            width=button_width,
+            height=30,
+            left=15,
+            top=top,
+        )
+        actions.add_child(name, widgets[name])
+        top += step
+
+    inspector = Window(
+        "Selection",
+        width=320,
+        height=520,
+        align=WindowAlignment.RIGHT,
+        theme=scene.ui_theme,
+    )
+    widgets["inspector_window"] = inspector
+
+    inspector.add_child(
+        "selected_label",
+        Button("Selected Object", width=290, height=30, left=15, top=40),
+    )
+    widgets["selected_name"] = Button(
+        "None",
+        width=290,
+        height=30,
+        left=15,
+        top=80,
+    )
+    inspector.add_child("selected_name", widgets["selected_name"])
+
+    inspector.add_child(
+        "selected_type_label",
+        Button("Primitive Type", width=290, height=30, left=15, top=120),
+    )
+    widgets["selected_type"] = Button(
+        "-",
+        width=290,
+        height=30,
+        left=15,
+        top=160,
+    )
+    inspector.add_child("selected_type", widgets["selected_type"])
+
+    inspector.add_child(
+        "position_label",
+        Button("Position (x, y, z)", width=290, height=30, left=15, top=200),
+    )
+    widgets["position"] = EditBox(
+        "0.000, 0.000, 0.500",
+        width=290,
+        height=30,
+        left=15,
+        top=240,
+        on_change=scene.set_position_text,
+    )
+    inspector.add_child("position", widgets["position"])
+
+    inspector.add_child(
+        "rotation_label",
+        Button("Rotation Degrees (x, y, z)", width=290, height=30, left=15, top=280),
+    )
+    widgets["rotation"] = EditBox(
+        "0.000, 0.000, 0.000",
+        width=290,
+        height=30,
+        left=15,
+        top=320,
+        on_change=scene.set_rotation_text,
+    )
+    inspector.add_child("rotation", widgets["rotation"])
+
+    inspector.add_child(
+        "scale_label",
+        Button("Scale (x, y, z)", width=290, height=30, left=15, top=360),
+    )
+    widgets["scale"] = EditBox(
+        "1.000, 1.000, 1.000",
+        width=290,
+        height=30,
+        left=15,
+        top=400,
+        on_change=scene.set_scale_text,
+    )
+    inspector.add_child("scale", widgets["scale"])
+
+    inspector.add_child(
+        "color_label",
+        Button("Color RGB 0-1", width=290, height=30, left=15, top=440),
+    )
+    widgets["color"] = EditBox(
+        "0.400, 0.700, 1.000",
+        width=290,
+        height=30,
+        left=15,
+        top=480,
+        on_change=scene.set_color_text,
+    )
+    inspector.add_child("color", widgets["color"])
+
+    hud.add_child("actions", actions)
+    hud.add_child("inspector", inspector)
+    return hud, widgets

--- a/examples/tools/05_subdivide.py
+++ b/examples/tools/05_subdivide.py
@@ -8,8 +8,11 @@ texture_file = os.path.join(os.path.dirname(__file__), "../basics/cube.png")
 object_file = os.path.join(os.path.dirname(__file__), "../basics/monkey.obj")
 
 
+# 4-way midpoint subdivision: each pass multiplies face count by 4.
+# Use 3 passes (968 → ~62k faces) for a good balance of detail vs performance;
+# 4 passes yields ~248k faces which is visually identical but slower to build.
 monkey = Wavefront(filename=object_file)
-for _ in range(4):
+for _ in range(3):
     monkey = subdivide(monkey)
 
 normal_monkey = Wavefront(filename=object_file)

--- a/payton/math/functions.py
+++ b/payton/math/functions.py
@@ -197,7 +197,9 @@ def vector_angle(v1: Vector3D, v2: Vector3D) -> float:
     """
     v1_n = normalize_vector(v1)
     v2_n = normalize_vector(v2)
-    return math.acos(dot_product(v1_n, v2_n) / (vector_norm(v1_n) * vector_norm(v2_n)))
+    # Clamp to [-1, 1] to guard against floating-point drift causing math domain error
+    dot = max(-1.0, min(1.0, dot_product(v1_n, v2_n)))
+    return math.acos(dot)
 
 
 def mid_point(v1: Vector3D, v2: Vector3D) -> Vector3D:

--- a/payton/scene/__init__.py
+++ b/payton/scene/__init__.py
@@ -22,7 +22,15 @@ module
 
 # pylama:ignore=W
 from payton.scene.physics import physics_client
-from payton.scene.scene import SHADOW_HIGH, SHADOW_LOW, SHADOW_MID, SHADOW_NONE, Background, Scene
+from payton.scene.scene import (
+    SHADOW_HIGH,
+    SHADOW_LOW,
+    SHADOW_MID,
+    SHADOW_NONE,
+    Background,
+    Scene,
+)
+from payton.scene.theme import THEME_BLENDER, THEME_GAMEENGINE, THEME_STUDIO, SceneTheme
 
 __all__ = [
     "Scene",
@@ -32,4 +40,8 @@ __all__ = [
     "SHADOW_MID",
     "SHADOW_NONE",
     "physics_client",
+    "SceneTheme",
+    "THEME_BLENDER",
+    "THEME_STUDIO",
+    "THEME_GAMEENGINE",
 ]

--- a/payton/scene/geometry/base.py
+++ b/payton/scene/geometry/base.py
@@ -49,9 +49,21 @@ from payton.math.functions import (
     vector_transform,
 )
 from payton.math.geometry import raycast_sphere_intersect
-from payton.math.matrix import IDENTITY_MATRIX, Matrix, matrix_to_position_and_quaternion
+from payton.math.matrix import (
+    IDENTITY_MATRIX,
+    Matrix,
+    matrix_to_position_and_quaternion,
+)
 from payton.math.vector import Vector2D, Vector3D
-from payton.scene.material import DEFAULT, NO_INDICE, NO_VERTEX_ARRAY, POINTS, SOLID, WIREFRAME, Material
+from payton.scene.material import (
+    DEFAULT,
+    NO_INDICE,
+    NO_VERTEX_ARRAY,
+    POINTS,
+    SOLID,
+    WIREFRAME,
+    Material,
+)
 from payton.scene.shader import DEFAULT_SHADER, PARTICLE_SHADER, Shader
 from payton.scene.types import IList, VList
 

--- a/payton/scene/geometry/base.py
+++ b/payton/scene/geometry/base.py
@@ -837,11 +837,11 @@ class Object:
 
         for material in self.materials.values():
             if len(material._indices) == 0:
-                material._vao == NO_INDICE
+                material._vao = NO_INDICE
                 continue
 
-            if material._vao == NO_VERTEX_ARRAY:
-                # Generate Vertex Array
+            if material._vao == NO_VERTEX_ARRAY or material._vao == NO_INDICE:
+                # Generate Vertex Array (also handles transition from NO_INDICE when indices are added later)
                 material._vao = glGenVertexArrays(1)
                 # We need 1 buffer for material as indices
                 material._vbos = [glGenBuffers(1)]

--- a/payton/scene/geometry/capsule.py
+++ b/payton/scene/geometry/capsule.py
@@ -9,6 +9,7 @@ from payton.scene.material import DEFAULT
 _BULLET = False
 try:
     import importlib.util
+
     _BULLET = importlib.util.find_spec("pybullet") is not None
 except (ModuleNotFoundError, ImportError):
     _BULLET = False
@@ -36,12 +37,12 @@ class Capsule(Mesh):
         height -- Height of the cylindrical part (total height will be height + radius_top + radius_bottom)
         meridians -- Number of vertical segments around the circumference
         parallels -- Number of horizontal segments in each hemisphere
-        
+
         Note: If radius is provided, it overrides radius_top and radius_bottom.
         If radius is None, radius_top and radius_bottom default to 0.5.
         """
         super().__init__(**kwargs)
-        
+
         # Handle radius parameters with backward compatibility
         if radius is not None:
             self.radius_top = radius
@@ -50,8 +51,10 @@ class Capsule(Mesh):
         else:
             self.radius_top = radius_top if radius_top is not None else 0.5
             self.radius_bottom = radius_bottom if radius_bottom is not None else 0.5
-            self.radius = max(self.radius_top, self.radius_bottom)  # For collision shape
-            
+            self.radius = max(
+                self.radius_top, self.radius_bottom
+            )  # For collision shape
+
         self.height: float = height
         self.meridians: int = meridians
         self.parallels: int = parallels
@@ -60,16 +63,16 @@ class Capsule(Mesh):
     def build_capsule(self) -> bool:
         """Build the capsule based on the initial parameters."""
         self.clear_triangles()
-        
+
         # Build the cylindrical body
         self._build_cylinder_body()
-        
+
         # Build the top hemisphere
         self._build_hemisphere(top=True)
-        
+
         # Build the bottom hemisphere
         self._build_hemisphere(top=False)
-        
+
         return True
 
     def _build_cylinder_body(self) -> None:
@@ -83,24 +86,24 @@ class Capsule(Mesh):
             # Current and next angle
             angle1 = step_angle * i
             angle2 = step_angle * (i + 1)
-            
+
             # Calculate vertices for tapered cylinder
             # Bottom (use radius_bottom)
             x1_bot = self.radius_bottom * math.cos(angle1)
             y1_bot = self.radius_bottom * math.sin(angle1)
             x2_bot = self.radius_bottom * math.cos(angle2)
             y2_bot = self.radius_bottom * math.sin(angle2)
-            
+
             # Top (use radius_top)
             x1_top = self.radius_top * math.cos(angle1)
             y1_top = self.radius_top * math.sin(angle1)
             x2_top = self.radius_top * math.cos(angle2)
             y2_top = self.radius_top * math.sin(angle2)
-            
+
             # UV coordinates
             u1 = u_step * i
             u2 = u_step * (i + 1)
-            
+
             # Create quad as two triangles
             # Bottom vertices
             v1 = [x1_bot, y1_bot, -h_2]
@@ -108,31 +111,31 @@ class Capsule(Mesh):
             # Top vertices
             v3 = [x1_top, y1_top, h_2]
             v4 = [x2_top, y2_top, h_2]
-            
+
             # Calculate normals for tapered surface correctly
             def calculate_frustum_normal(angle: float) -> List[float]:
                 """Calculate the normal for a frustum surface at given angle."""
                 # Direction vectors
                 cos_a, sin_a = math.cos(angle), math.sin(angle)
-                
+
                 # Surface tangent vectors
                 # Circumferential direction (tangent to circle)
                 tangent_u = [-sin_a, cos_a, 0.0]
-                
+
                 # Axial direction (from bottom to top, accounting for radius change)
                 tangent_v = [
                     (self.radius_top - self.radius_bottom) * cos_a,
                     (self.radius_top - self.radius_bottom) * sin_a,
-                    self.height
+                    self.height,
                 ]
-                
+
                 # Cross product gives surface normal (tangent_u × tangent_v)
                 normal = [
                     tangent_u[1] * tangent_v[2] - tangent_u[2] * tangent_v[1],
                     tangent_u[2] * tangent_v[0] - tangent_u[0] * tangent_v[2],
-                    tangent_u[0] * tangent_v[1] - tangent_u[1] * tangent_v[0]
+                    tangent_u[0] * tangent_v[1] - tangent_u[1] * tangent_v[0],
                 ]
-                
+
                 # Normalize
                 length = math.sqrt(sum(n**2 for n in normal))
                 if length > 0:
@@ -140,51 +143,55 @@ class Capsule(Mesh):
                 else:
                     # Fallback to radial direction for degenerate case
                     normal = [cos_a, sin_a, 0.0]
-                
+
                 return normal
-            
+
             # Calculate normals at the two angles
             normal1 = calculate_frustum_normal(angle1)
             normal2 = calculate_frustum_normal(angle2)
-            
+
             # Add vertices
             self._vertices.extend([v1, v2, v3, v4])
-            
+
             # Add texture coordinates
             self._texcoords.extend([[u1, 0.0], [u2, 0.0], [u1, 1.0], [u2, 1.0]])
-            
+
             # Add normals (same normal for top and bottom vertices at each angle)
             self._normals.extend([normal1, normal2, normal1, normal2])
-            
+
             # Add triangles (quad = 2 triangles)
             self._indices.append([indices, indices + 1, indices + 2])
             self._indices.append([indices + 1, indices + 3, indices + 2])
             self.materials[DEFAULT]._indices.append([indices, indices + 1, indices + 2])
-            self.materials[DEFAULT]._indices.append([indices + 1, indices + 3, indices + 2])
-            
+            self.materials[DEFAULT]._indices.append(
+                [indices + 1, indices + 3, indices + 2]
+            )
+
             indices += 4
 
     def _build_hemisphere(self, top: bool = True) -> None:
         """Build a hemisphere cap.
-        
+
         Args:
             top: If True, build top hemisphere, otherwise bottom hemisphere
         """
         # Use appropriate radius for this hemisphere
         radius = self.radius_top if top else self.radius_bottom
-        
+
         step_angle = math.radians(360.0 / self.meridians)
-        step_height = math.radians(90.0 / self.parallels)  # Only 90 degrees for hemisphere
+        step_height = math.radians(
+            90.0 / self.parallels
+        )  # Only 90 degrees for hemisphere
         u_step = 1.0 / self.meridians
         v_step = 1.0 / self.parallels
         h_2 = self.height / 2.0
         indices = len(self._vertices)
-        
+
         # Determine the z offset and angle range based on top/bottom
         z_offset = h_2 if top else -h_2
         start_angle = 0.0 if top else math.radians(90.0)
         angle_multiplier = 1 if top else -1
-        
+
         for i in range(self.parallels):
             for j in range(self.meridians):
                 # Calculate the four vertices of this segment
@@ -192,75 +199,85 @@ class Capsule(Mesh):
                 h2 = start_angle + angle_multiplier * step_height * (i + 1)
                 a1 = step_angle * j
                 a2 = step_angle * (j + 1)
-                
+
                 # First vertex
                 x1 = radius * math.sin(h1) * math.cos(a1)
                 y1 = radius * math.sin(h1) * math.sin(a1)
                 z1 = radius * math.cos(h1) * angle_multiplier + z_offset
-                
+
                 # Second vertex
                 x2 = radius * math.sin(h2) * math.cos(a1)
                 y2 = radius * math.sin(h2) * math.sin(a1)
                 z2 = radius * math.cos(h2) * angle_multiplier + z_offset
-                
+
                 # Third vertex
                 x3 = radius * math.sin(h2) * math.cos(a2)
                 y3 = radius * math.sin(h2) * math.sin(a2)
                 z3 = radius * math.cos(h2) * angle_multiplier + z_offset
-                
+
                 # Fourth vertex
                 x4 = radius * math.sin(h1) * math.cos(a2)
                 y4 = radius * math.sin(h1) * math.sin(a2)
                 z4 = radius * math.cos(h1) * angle_multiplier + z_offset
-                
+
                 # Texture coordinates
                 u1 = u_step * j
                 u2 = u_step * j
                 u3 = u_step * (j + 1)
                 u4 = u_step * (j + 1)
-                
+
                 v1 = v_step * i
                 v2 = v_step * (i + 1)
                 v3 = v_step * (i + 1)
                 v4 = v_step * i
-                
+
                 # Calculate normals (pointing outward from center)
                 def normalize(vec: List[float]) -> List[float]:
                     length = math.sqrt(sum(v**2 for v in vec))
                     return [v / length if length > 0 else 0 for v in vec]
-                
+
                 n1 = normalize([x1, y1, z1 - z_offset])
                 n2 = normalize([x2, y2, z2 - z_offset])
                 n3 = normalize([x3, y3, z3 - z_offset])
                 n4 = normalize([x4, y4, z4 - z_offset])
-                
+
                 # Add vertices
-                self._vertices.extend([[x1, y1, z1], [x2, y2, z2], [x3, y3, z3], [x4, y4, z4]])
-                
+                self._vertices.extend(
+                    [[x1, y1, z1], [x2, y2, z2], [x3, y3, z3], [x4, y4, z4]]
+                )
+
                 # Add texture coordinates
                 self._texcoords.extend([[u1, v1], [u2, v2], [u3, v3], [u4, v4]])
-                
+
                 # Add normals
                 self._normals.extend([n1, n2, n3, n4])
-                
+
                 # Add triangles
                 if top:
                     self._indices.append([indices, indices + 1, indices + 2])
                     self._indices.append([indices, indices + 2, indices + 3])
-                    self.materials[DEFAULT]._indices.append([indices, indices + 1, indices + 2])
-                    self.materials[DEFAULT]._indices.append([indices, indices + 2, indices + 3])
+                    self.materials[DEFAULT]._indices.append(
+                        [indices, indices + 1, indices + 2]
+                    )
+                    self.materials[DEFAULT]._indices.append(
+                        [indices, indices + 2, indices + 3]
+                    )
                 else:
                     # Reverse winding for bottom hemisphere
                     self._indices.append([indices, indices + 2, indices + 1])
                     self._indices.append([indices, indices + 3, indices + 2])
-                    self.materials[DEFAULT]._indices.append([indices, indices + 2, indices + 1])
-                    self.materials[DEFAULT]._indices.append([indices, indices + 3, indices + 2])
-                
+                    self.materials[DEFAULT]._indices.append(
+                        [indices, indices + 2, indices + 1]
+                    )
+                    self.materials[DEFAULT]._indices.append(
+                        [indices, indices + 3, indices + 2]
+                    )
+
                 indices += 4
 
     def _create_collision_shape(self) -> None:
         """Create bullet physics collision shape for the capsule.
-        
+
         Note: Bullet Physics doesn't support tapered capsules natively,
         so we use the larger radius for a conservative collision shape.
         """

--- a/payton/scene/geometry/md2.py
+++ b/payton/scene/geometry/md2.py
@@ -10,7 +10,17 @@ import os
 import struct
 import time
 from copy import deepcopy
-from typing import Any, BinaryIO, Dict, Generator, List, NamedTuple, Optional, Tuple, cast
+from typing import (
+    Any,
+    BinaryIO,
+    Dict,
+    Generator,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    cast,
+)
 
 import numpy as np
 

--- a/payton/scene/geometry/mesh.py
+++ b/payton/scene/geometry/mesh.py
@@ -85,9 +85,10 @@ class Mesh(Object):
         normal = plane_normal(v1, v2, v3)
         if reverse:
             normal = invert_vector(normal)
-        self._normals[i1] = normal
-        self._normals[i2] = normal
-        self._normals[i3] = normal
+        # Assign independent copies so vertices don't share the same list object
+        self._normals[i1] = list(normal)
+        self._normals[i2] = list(normal)
+        self._normals[i3] = list(normal)
         return True
 
     def fix_normals(self, reverse: bool = False) -> None:
@@ -99,7 +100,7 @@ class Mesh(Object):
         Keyword arguments:
         reverse -- Force reversing the normal directions.
         """
-        self._normals = [[0, 0, 1.0]] * len(self._vertices)
+        self._normals = [[0.0, 0.0, 1.0] for _ in range(len(self._vertices))]
 
         [
             self._calc_normal(face[0], face[1], face[2], reverse)
@@ -118,9 +119,10 @@ class Mesh(Object):
         self._calc_bounds()
         bbox = self.bounding_box
         vmin, vmax = bbox[0], bbox[1]
-        width = vmax[0] - vmin[0]
-        depth = vmax[1] - vmin[1]
-        height = vmax[2] - vmin[2]
+        # Guard against division-by-zero on flat/degenerate meshes
+        width = max(vmax[0] - vmin[0], 1e-10)
+        depth = max(vmax[1] - vmin[1], 1e-10)
+        height = max(vmax[2] - vmin[2], 1e-10)
         normals = [
             [0.0, -1.0, 0.0],  # front
             [1.0, 0.0, 0.0],  # right
@@ -233,9 +235,9 @@ class Mesh(Object):
             for color in colors:
                 self._vertex_colors.append(color)
 
+        i = len(self._vertices)
         self._vertices += vertices
 
-        i = len(self._indices) * 3
         self._indices.append([i, i + 1, i + 2])
         self.materials[material]._indices.append([i, i + 1, i + 2])
         for normal in normals:

--- a/payton/scene/geometry/ragdoll.py
+++ b/payton/scene/geometry/ragdoll.py
@@ -598,7 +598,13 @@ class RagDoll(Object):
             self._current_frame = frame_number
             self.set_keyframe(frame_number)
 
-    def render(self, lit: bool, shader: Shader, parent_matrix: Optional[np.ndarray] = None, _primitive: Optional[int] = None) -> None:
+    def render(
+        self,
+        lit: bool,
+        shader: Shader,
+        parent_matrix: Optional[np.ndarray] = None,
+        _primitive: Optional[int] = None,
+    ) -> None:
         """Render with animation update."""
         if not self._visible:
             return

--- a/payton/scene/grid.py
+++ b/payton/scene/grid.py
@@ -43,6 +43,8 @@ class Grid:
         xres: int = 20,
         yres: int = 20,
         color: Optional[Vector3D] = None,
+        major_color: Optional[Vector3D] = None,
+        major_interval: int = 5,
         **kwargs: Any,
     ) -> None:
         """Initialize the Grid
@@ -50,9 +52,14 @@ class Grid:
         Keyword arguments:
         xres -- Number of steps in X direction
         yres -- Number of steps in Y direction
-        color -- Color of the grid.
+        color -- Color of the minor grid lines.
+        major_color -- Color of the major grid lines (every *major_interval*
+            units).  ``None`` disables major-line differentiation.
+        major_interval -- Unit interval between major grid lines (default 5).
         """
-        self._color = [0.4, 0.4, 0.4, 1.0] if color is None else color
+        self._color = [0.35, 0.35, 0.35, 1.0] if color is None else color
+        self._major_color: Optional[Vector3D] = major_color
+        self._major_interval: int = max(1, major_interval)
         self.static: bool = True
         self.matrix: List[float] = [
             1.0,
@@ -78,7 +85,9 @@ class Grid:
         self._model_matrix: Optional[np.ndarray] = None
         self._material: Material = Material(display=1, lights=False)
         self._material.color = self._color
-        self._lines: List[Line] = [
+        self._xres: int = xres
+        self._yres: int = yres
+        self._axis_lines: List[Line] = [
             Line(
                 vertices=[
                     [0.0, 0.0, 0.01],
@@ -101,6 +110,8 @@ class Grid:
                 color=[0.0, 0.0, 1.0],
             ),
         ]
+        self._major_lines: List[Line] = []
+        self._lines: List[Line] = self._axis_lines  # kept for back-compat
 
         # Vertex Array Object pointer
         self._vao: int = -1
@@ -113,7 +124,9 @@ class Grid:
         if self._vao > -1:
             glDeleteVertexArrays(1, [self._vao])
             self._vao = -1
-        for line in self._lines:
+        for line in self._axis_lines:
+            line.destroy()
+        for line in self._major_lines:
             line.destroy()
         return True
 
@@ -148,7 +161,9 @@ class Grid:
             glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
             glBindVertexArray(0)
 
-        for line in self._lines:
+        for line in self._major_lines:
+            line.render(False, shader, None)
+        for line in self._axis_lines:
             line.render(False, shader, None)
         return True
 
@@ -160,11 +175,15 @@ class Grid:
         yres -- Number of steps in Y direction
         spacing -- Grid spacing
         """
+        self._xres = xres
+        self._yres = yres
         self._vertices = []
         self._indices = []
         self._vertex_count = 0
         ystart = -(yres * spacing / 2.0)
         xstart = -(xres * spacing / 2.0)
+        xend = xres * spacing / 2.0
+        yend = yres * spacing / 2.0
         self._model_matrix = np.asfortranarray(
             np.array(self.matrix, dtype=np.float32), dtype=np.float32
         )
@@ -193,6 +212,36 @@ class Grid:
         if self._vao > -1:
             glDeleteVertexArrays(1, [self._vao])
         self._vao = -1
+
+        # Rebuild major grid lines if a major colour is configured
+        for line in self._major_lines:
+            line.destroy()
+        self._major_lines = []
+
+        if self._major_color is not None:
+            mc = list(self._major_color)
+            # Vertical major lines (parallel to Y axis)
+            x = xstart
+            while x <= xend + spacing * 0.01:
+                if abs(round(x / spacing) % self._major_interval) < 0.01:
+                    self._major_lines.append(
+                        Line(
+                            vertices=[[x, ystart, 0.01], [x, yend, 0.01]],
+                            color=mc,
+                        )
+                    )
+                x += spacing
+            # Horizontal major lines (parallel to X axis)
+            y = ystart
+            while y <= yend + spacing * 0.01:
+                if abs(round(y / spacing) % self._major_interval) < 0.01:
+                    self._major_lines.append(
+                        Line(
+                            vertices=[[xstart, y, 0.01], [xend, y, 0.01]],
+                            color=mc,
+                        )
+                    )
+                y += spacing
 
     @property
     def color(self) -> Vector3D:

--- a/payton/scene/gui/__init__.py
+++ b/payton/scene/gui/__init__.py
@@ -4,6 +4,9 @@
 from payton.scene.gui.base import Hud, Rectangle, Shape2D, Text
 from payton.scene.gui.help import info_box
 from payton.scene.gui.window import (
+    UI_THEME_BLENDER,
+    UI_THEME_GAMEENGINE,
+    UI_THEME_STUDIO,
     Button,
     EditBox,
     Panel,
@@ -22,6 +25,9 @@ __all__ = [
     "Shape2D",
     "Text",
     "Theme",
+    "UI_THEME_BLENDER",
+    "UI_THEME_GAMEENGINE",
+    "UI_THEME_STUDIO",
     "Window",
     "WindowAlignment",
 ]

--- a/payton/scene/gui/__init__.py
+++ b/payton/scene/gui/__init__.py
@@ -3,7 +3,14 @@
 
 from payton.scene.gui.base import Hud, Rectangle, Shape2D, Text
 from payton.scene.gui.help import info_box
-from payton.scene.gui.window import Button, EditBox, Panel, Theme, Window, WindowAlignment
+from payton.scene.gui.window import (
+    Button,
+    EditBox,
+    Panel,
+    Theme,
+    Window,
+    WindowAlignment,
+)
 
 __all__ = [
     "Button",

--- a/payton/scene/gui/base.py
+++ b/payton/scene/gui/base.py
@@ -141,7 +141,7 @@ class Shape2D(Mesh):
             for child in self.children:
                 c = cast(Mesh, self.children[child]).click(x, y)
                 if c:
-                    return cast(Mesh, self.children[child])
+                    return c
             return None
 
         if self._model_matrix is None:
@@ -343,19 +343,20 @@ class Hud(Object):
         self._fontname: str = font
         self.children: Dict[str, Object] = {}
         self._font_size: int = font_size
-        if self._fontname != "":
-            self.set_font(self._fontname, self._font_size)
         self._font: ImageFont | None = None
         self._projection_matrix: Optional[np.ndarray] = None
-        try:
-            self.set_font(
-                os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), "monofonto.ttf"
+        if self._fontname != "":
+            self.set_font(self._fontname, self._font_size)
+        else:
+            try:
+                self.set_font(
+                    os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)), "monofonto.ttf"
+                    )
                 )
-            )
-        except OSError:
-            # font not found but pillow has better than nothinf font
-            pass
+            except OSError:
+                # font not found but pillow has a fallback font
+                pass
 
     @property
     def font(self) -> ImageFont | None:

--- a/payton/scene/gui/help.py
+++ b/payton/scene/gui/help.py
@@ -23,11 +23,17 @@ F2: Previous Camera F3: Next Camera
     help_window = Window(
         align=WindowAlignment.RIGHT,
         title="How to use Payton Scene",
-        height=10000,
+        height=500,
         width=520,
     )
     help_window.add_child(
-        "text", Button(width=500, height=400, left=10, top=40, label=text)
+        "text",
+        Text(
+            position=[10, 40],
+            size=[500, 440],
+            label=text,
+            color=[0.95, 0.95, 0.95],
+        ),
     )
     return help_window
 

--- a/payton/scene/gui/window.py
+++ b/payton/scene/gui/window.py
@@ -9,39 +9,97 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
+from PIL import Image, ImageDraw
 
 from payton.math.vector import Vector3D
 from payton.scene.geometry.base import Object
-from payton.scene.gui.base import Shape2D, Text, text_size
+from payton.scene.gui.base import Shape2D, Text
 from payton.scene.shader import Shader
+from payton.scene.theme import SceneTheme
+
+# Height in pixels of the window title bar
+TITLE_BAR_HEIGHT: int = 28
 
 
 class Theme:
     """User interface theme"""
 
     def __init__(self) -> None:
-        """Initialize the theme"""
-        self.opacity = 0.9
+        """Initialize the theme with a modern dark-editor palette."""
+        self.opacity: float = 0.9
 
-        self.background_color: Vector3D = [0.05, 0.05, 0.05]
-        self.text_color: Vector3D = [1.0, 1.0, 1.0]
-        self.title_background_color: Vector3D = [
-            235 / 255,
-            210 / 255,
-            52 / 255,
-        ]
-        self.title_text_color: Vector3D = [0.0, 0.0, 0.0]
+        self.background_color: Vector3D = [0.12, 0.12, 0.14]
+        self.text_color: Vector3D = [0.95, 0.95, 0.95]
+        self.title_background_color: Vector3D = [0.20, 0.45, 0.75]
+        self.title_text_color: Vector3D = [1.0, 1.0, 1.0]
+        self.border_color: Vector3D = [0.08, 0.08, 0.10]
+        self.highlight_color: Vector3D = [0.35, 0.60, 0.90]
 
     def secondary(self) -> None:
-        """Secondary colors for the theme"""
-        self.background_color, self.text_color = (
+        """Swap background/title palettes (e.g. for EditBox active state)."""
+        # Simultaneous swap — no temporary variable needed in Python
+        self.background_color, self.title_background_color = (
             self.title_background_color,
-            self.title_text_color,
-        )
-        self.title_background_color, self.title_text_color = (
             self.background_color,
+        )
+        self.text_color, self.title_text_color = (
+            self.title_text_color,
             self.text_color,
         )
+
+    @classmethod
+    def from_scene_theme(cls, scene_theme: SceneTheme) -> "Theme":
+        """Derive a UI Theme whose palette is coherent with a SceneTheme.
+
+        The window background is drawn from the scene's bottom background
+        colour (darkened slightly).  The title bar takes the scene's light
+        colour (desaturated to a cool tint).  Text colours are chosen for
+        maximum contrast.
+
+        Keyword arguments:
+        scene_theme -- A :class:`~payton.scene.theme.SceneTheme` instance.
+        """
+        t = cls()
+
+        # -- Background: darken the bottom background colour
+        bb = scene_theme.background_bottom_color
+        t.background_color = [
+            max(bb[0] * 0.7, 0.06),
+            max(bb[1] * 0.7, 0.06),
+            max(bb[2] * 0.7, 0.08),
+        ]
+        t.border_color = [
+            max(t.background_color[0] - 0.04, 0.0),
+            max(t.background_color[1] - 0.04, 0.0),
+            max(t.background_color[2] - 0.04, 0.0),
+        ]
+
+        # -- Title bar: derived from scene light colour with a blue tint
+        lc = scene_theme.light_color
+        title = [
+            lc[0] * 0.25 + 0.10,
+            lc[1] * 0.25 + 0.25,
+            lc[2] * 0.40 + 0.35,
+        ]
+        t.title_background_color = [min(c, 1.0) for c in title]
+        t.highlight_color = [min(c + 0.15, 1.0) for c in t.title_background_color]
+
+        # -- Text contrast: pick white or black based on background luminance
+        bg_lum = (
+            0.2126 * t.background_color[0]
+            + 0.7152 * t.background_color[1]
+            + 0.0722 * t.background_color[2]
+        )
+        t.text_color = [0.95, 0.95, 0.95] if bg_lum < 0.5 else [0.05, 0.05, 0.05]
+
+        tb_lum = (
+            0.2126 * t.title_background_color[0]
+            + 0.7152 * t.title_background_color[1]
+            + 0.0722 * t.title_background_color[2]
+        )
+        t.title_text_color = [1.0, 1.0, 1.0] if tb_lum < 0.5 else [0.05, 0.05, 0.05]
+
+        return t
 
 
 class WindowAlignment(Enum):
@@ -186,11 +244,10 @@ class Window(WindowElement):
             "title",
             Text(
                 position=[10, 0, 0],
-                size=[self.size[0], 20],
+                size=[self.size[0], TITLE_BAR_HEIGHT],
                 label=self.title,
-                # bgcolor=self.theme.title_background_color,
                 color=self.theme.title_text_color,
-                opacity=0.5,
+                opacity=0.8,
             ),
         )
 
@@ -198,10 +255,12 @@ class Window(WindowElement):
         """Create the frame polygons"""
         super().draw()
         w, h = self.size[0], self.size[1]
+        tb = TITLE_BAR_HEIGHT
         self.clear_triangles()
         if not self._init:
+            # Content area
             self.add_triangle(
-                [[0, 22, 1], [w, h, 1], [w, 22, 1]],
+                [[0, tb, 1], [w, h, 1], [w, tb, 1]],
                 texcoords=[[0, 0], [1, 1], [1, 0]],
                 colors=[
                     self.theme.background_color,
@@ -210,7 +269,7 @@ class Window(WindowElement):
                 ],
             )
             self.add_triangle(
-                [[0, 22, 1], [0, h, 1], [w, h, 1]],
+                [[0, tb, 1], [0, h, 1], [w, h, 1]],
                 texcoords=[[0, 0], [0, 1], [1, 1]],
                 colors=[
                     self.theme.background_color,
@@ -218,8 +277,9 @@ class Window(WindowElement):
                     self.theme.background_color,
                 ],
             )
+            # Title bar
             self.add_triangle(
-                [[0, 0, 1], [w - 1, 22, 1], [w - 1, 0, 1]],
+                [[0, 0, 1], [w - 1, tb, 1], [w - 1, 0, 1]],
                 texcoords=[[0, 0], [1, 1], [1, 0]],
                 colors=[
                     self.theme.title_background_color,
@@ -228,12 +288,33 @@ class Window(WindowElement):
                 ],
             )
             self.add_triangle(
-                [[0, 0, 1], [0, 22, 1], [w - 1, 22, 1]],
+                [[0, 0, 1], [0, tb, 1], [w - 1, tb, 1]],
                 texcoords=[[0, 0], [1, 1], [1, 0]],
                 colors=[
                     self.theme.title_background_color,
                     self.theme.title_background_color,
                     self.theme.title_background_color,
+                ],
+            )
+            # Separator line between title bar and content area
+            sep_y = tb
+            sep_bottom = tb + 2
+            self.add_triangle(
+                [[0, sep_y, 1], [w, sep_bottom, 1], [w, sep_y, 1]],
+                texcoords=[[0, 0], [1, 1], [1, 0]],
+                colors=[
+                    self.theme.border_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
+                ],
+            )
+            self.add_triangle(
+                [[0, sep_y, 1], [0, sep_bottom, 1], [w, sep_bottom, 1]],
+                texcoords=[[0, 0], [0, 1], [1, 1]],
+                colors=[
+                    self.theme.border_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
                 ],
             )
             self._init = True
@@ -248,26 +329,28 @@ class Panel(WindowElement):
         w, h = self.size[0], self.size[1]
         self.clear_triangles()
         if not self._init:
+            # Outer border (2 px)
             self.add_triangle(
                 [[0, 0, 1], [w, h, 1], [w, 0, 1]],
                 texcoords=[[0, 0], [1, 1], [1, 0]],
                 colors=[
-                    self.theme.title_background_color,
-                    self.theme.title_background_color,
-                    self.theme.title_background_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
                 ],
             )
             self.add_triangle(
                 [[0, 0, 1], [0, h, 1], [w, h, 1]],
                 texcoords=[[0, 0], [0, 1], [1, 1]],
                 colors=[
-                    self.theme.title_background_color,
-                    self.theme.title_background_color,
-                    self.theme.title_background_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
+                    self.theme.border_color,
                 ],
             )
+            # Inner fill (inset 2 px)
             self.add_triangle(
-                [[1, 1, 1], [w - 1, h - 1, 1], [w - 1, 1, 1]],
+                [[2, 2, 1], [w - 2, h - 2, 1], [w - 2, 2, 1]],
                 texcoords=[[0, 0], [1, 1], [1, 0]],
                 colors=[
                     self.theme.background_color,
@@ -276,12 +359,31 @@ class Panel(WindowElement):
                 ],
             )
             self.add_triangle(
-                [[1, 1, 1], [1, h - 1, 1], [w - 1, h - 1, 1]],
+                [[2, 2, 1], [2, h - 2, 1], [w - 2, h - 2, 1]],
                 texcoords=[[0, 0], [0, 1], [1, 1]],
                 colors=[
                     self.theme.background_color,
                     self.theme.background_color,
                     self.theme.background_color,
+                ],
+            )
+            # Top-edge highlight stripe (1 px bevel effect)
+            self.add_triangle(
+                [[2, 2, 1], [w - 2, 3, 1], [w - 2, 2, 1]],
+                texcoords=[[0, 0], [1, 1], [1, 0]],
+                colors=[
+                    self.theme.highlight_color,
+                    self.theme.highlight_color,
+                    self.theme.highlight_color,
+                ],
+            )
+            self.add_triangle(
+                [[2, 2, 1], [2, 3, 1], [w - 2, 3, 1]],
+                texcoords=[[0, 0], [0, 1], [1, 1]],
+                colors=[
+                    self.theme.highlight_color,
+                    self.theme.highlight_color,
+                    self.theme.highlight_color,
                 ],
             )
 
@@ -313,6 +415,7 @@ class Button(Panel):
         on_click -- On Click callback method
         """
         kwargs["on_click"] = on_click
+        height = max(height, 30)
         super().__init__(
             width=width,
             height=height,
@@ -322,7 +425,6 @@ class Button(Panel):
             theme=theme,
             **kwargs,
         )
-        height = max(height, 30)
 
         self._label = label
         self.text = Text(
@@ -334,34 +436,60 @@ class Button(Panel):
         self.add_child("label", self.text)
 
     def draw(self, **kwargs: Any) -> None:
-        """Create the button polygons"""
+        """Create the button polygons and position the text label."""
         super().draw()
-        text_area = self.text.text_size
 
-        ts = text_size(self._label, self.text.font)
-        x = (self.size[0] - text_area[0]) / 2
-        y = ((self.size[1] - text_area[1]) / 2) - (ts[1] / 2)
-        x = max(x, 0)
-        y = max(y, 0)
+        if self.text.font is None:
+            return
+
+        # Use the full textbbox so we know *where* text pixels land in the
+        # PIL image.  draw_text() renders at (1, 1), so actual text pixels
+        # span x:(1+bbox[0])..(1+bbox[2])  y:(1+bbox[1])..(1+bbox[3]).
+        # text_size() returns only bbox[2]-bbox[0] × bbox[3]-bbox[1], which
+        # is too small: the bottom bbox[1]+1 rows are always clipped.
+        timg = Image.new("RGBA", (1, 1))
+        d = ImageDraw.Draw(timg)
+        _bbox = d.textbbox((0, 0), self._label, font=self.text.font)
+        del d, timg
+        bbox = (int(_bbox[0]), int(_bbox[1]), int(_bbox[2]), int(_bbox[3]))
+
+        if bbox[2] <= bbox[0] or bbox[3] <= bbox[1]:
+            return  # empty / zero-size text
+
+        # PIL image dimensions: must fit all text pixels drawn at (1, 1).
+        img_w = bbox[2] + 2
+        img_h = bbox[3] + 2
+
+        # Centre of the rendered text region within the PIL image.
+        cx = 1.0 + (bbox[0] + bbox[2]) / 2.0
+        cy = 1.0 + (bbox[1] + bbox[3]) / 2.0
+
+        # Position the quad so its text centre aligns with the button centre.
+        xi = max(int(self.size[0] / 2.0 - cx), 0)
+        yi = max(int(self.size[1] / 2.0 - cy), 0)
 
         self.text.label = self._label
-        self.text.position = [x, y]
-        crop: List[int] = [0, 0, text_area[0], text_area[1] + 4]
+        crop: List[int] = [0, 0, 0, 0]
 
-        if text_area[0] > self.size[0]:
-            crop[0] = int((text_area[0] - self.size[0]) / 2.0)
-            crop[2] = int(text_area[0] - crop[0])
-            diff = int(crop[2] - crop[0])
-            text_area = (diff, text_area[1])
+        # If text image is wider than the button, centre-crop horizontally.
+        if img_w > self.size[0]:
+            overflow = img_w - int(self.size[0])
+            crop = [overflow // 2, 0, img_w - overflow // 2, img_h]
+            img_w = crop[2] - crop[0]
+            xi = 0
 
-        if text_area[1] > self.size[1]:
-            crop[1] = int((text_area[1] - self.size[1]) / 2.0)
-            crop[3] = int(text_area[1] - crop[1])
-            diff = int(crop[3] - crop[1])
-            text_area = (text_area[0], diff)
+        # If text image is taller than the button, centre-crop vertically.
+        if img_h > self.size[1]:
+            overflow = img_h - int(self.size[1])
+            crop[1] = overflow // 2
+            crop[3] = img_h - overflow // 2
+            img_h = crop[3] - crop[1]
+            yi = 0
 
         self.text.crop = crop
-        self.text.size = [int(text_area[0]), int(text_area[1]) + 10]
+        self.text.position = [xi, yi]
+        # Stable dimensions: derived from font metrics, not from text.size.
+        self.text.size = [max(img_w, 1), max(img_h, 1)]
 
     @property
     def label(self) -> str:
@@ -511,3 +639,19 @@ class EditBox(Panel):
             self.text.wrap(self.size[0])
         self.refresh()
         self._init = False
+
+
+# ---------------------------------------------------------------------------
+# Pre-built UI theme presets matching the built-in SceneTheme presets.
+# Import the SceneTheme presets and derive coherent UI palettes from them.
+# ---------------------------------------------------------------------------
+from payton.scene.theme import THEME_BLENDER, THEME_GAMEENGINE, THEME_STUDIO  # noqa: E402
+
+UI_THEME_BLENDER: Theme = Theme.from_scene_theme(THEME_BLENDER)
+"""UI theme that pairs with :data:`~payton.scene.theme.THEME_BLENDER`."""
+
+UI_THEME_STUDIO: Theme = Theme.from_scene_theme(THEME_STUDIO)
+"""UI theme that pairs with :data:`~payton.scene.theme.THEME_STUDIO`."""
+
+UI_THEME_GAMEENGINE: Theme = Theme.from_scene_theme(THEME_GAMEENGINE)
+"""UI theme that pairs with :data:`~payton.scene.theme.THEME_GAMEENGINE`."""

--- a/payton/scene/gui/window.py
+++ b/payton/scene/gui/window.py
@@ -469,7 +469,7 @@ class Button(Panel):
         yi = max(int(self.size[1] / 2.0 - cy), 0)
 
         self.text.label = self._label
-        crop: List[int] = [0, 0, 0, 0]
+        crop: List[int] = [0, 0, img_w, img_h]
 
         # If text image is wider than the button, centre-crop horizontally.
         if img_w > self.size[0]:

--- a/payton/scene/scene.py
+++ b/payton/scene/scene.py
@@ -87,6 +87,7 @@ from payton.scene.geometry.base import Object
 from payton.scene.grid import Grid
 from payton.scene.gui import Hud, Shape2D
 from payton.scene.gui.help import help_win
+from payton.scene.gui.window import Theme
 from payton.scene.light import Light
 from payton.scene.physics import physics_client
 from payton.scene.receiver import Receiver
@@ -222,6 +223,16 @@ class Scene(Receiver):
         self.active_camera = self.cameras[0]
 
         _theme: SceneTheme = theme if theme is not None else THEME_STUDIO
+
+        self.ui_theme: Theme = Theme.from_scene_theme(_theme)
+        """UI Theme derived from the scene's SceneTheme.
+
+        Pass this to :class:`~payton.scene.gui.window.Window` or other UI
+        elements to get a palette that is coherent with the 3-D scene::
+
+            scene = Scene(theme=THEME_STUDIO)
+            win   = Window("My Window", theme=scene.ui_theme)
+        """
 
         self.lights: List[Light] = []
         self.lights.append(

--- a/payton/scene/scene.py
+++ b/payton/scene/scene.py
@@ -106,6 +106,7 @@ from payton.scene.shader import (
     particle_geometry_shader,
     particle_vertex_shader,
 )
+from payton.scene.theme import THEME_BLENDER, THEME_GAMEENGINE, THEME_STUDIO, SceneTheme
 from payton.scene.types import CPlane
 
 try:
@@ -145,6 +146,7 @@ class Scene(Receiver):
         height: int = 600,
         on_select: Optional[Callable] = None,
         physics_force_continuous: bool = False,
+        theme: Optional[SceneTheme] = None,
         **kwargs: Any,
     ) -> None:
         """Create a new Scene.
@@ -160,6 +162,11 @@ class Scene(Receiver):
             callback receives a list of selected :class:`Object` instances.
         physics_force_continuous : bool, optional
             If True, forces the physics clock to run continuously.
+        theme : SceneTheme or None, optional
+            Visual theme for the scene.  Pass one of the built-in presets
+            (``THEME_BLENDER``, ``THEME_STUDIO``, ``THEME_GAMEENGINE``) or a
+            custom :class:`~payton.scene.theme.SceneTheme` instance.
+            Defaults to :data:`~payton.scene.theme.THEME_STUDIO`.
         **kwargs
             Ignored; kept for backward compatibility.
         """
@@ -214,14 +221,29 @@ class Scene(Receiver):
 
         self.active_camera = self.cameras[0]
 
-        self.lights: List[Light] = []
-        self.lights.append(Light())
+        _theme: SceneTheme = theme if theme is not None else THEME_STUDIO
 
-        self.grid = Grid()
+        self.lights: List[Light] = []
+        self.lights.append(
+            Light(
+                position=list(_theme.light_position),
+                color=list(_theme.light_color),
+            )
+        )
+
+        self.grid = Grid(
+            color=list(_theme.grid_color),
+            major_color=(
+                list(_theme.grid_major_color)
+                if _theme.grid_major_color is not None
+                else None
+            ),
+            major_interval=_theme.grid_major_interval,
+        )
         self.controller = Controller()
         self.controller.add_controller(GUIController())
         self.controller.add_controller(SceneController())
-        self.background = Background()
+        self.background = Background(theme=_theme)
         self.shaders: Dict[str, Shader] = {
             DEFAULT_SHADER: Shader(
                 fragment=default_fragment_shader, vertex=default_vertex_shader
@@ -260,6 +282,75 @@ class Scene(Receiver):
         self._render_lock = False
         self._shadow_quality = SHADOW_MID
         self._shadow_samples = 20
+
+    # ------------------------------------------------------------------
+    # Theme helpers
+    # ------------------------------------------------------------------
+
+    def apply_theme(self, theme: SceneTheme) -> None:
+        """Apply a :class:`~payton.scene.theme.SceneTheme` at any time.
+
+        Updates the background colours and mode, the grid colours, and the
+        first light's position and colour instantly — no need to recreate the
+        scene.
+
+        Parameters
+        ----------
+        theme : SceneTheme
+            Any :class:`SceneTheme` instance, including the built-in presets.
+
+        Example
+        -------
+        >>> from payton.scene import Scene, THEME_STUDIO
+        >>> scene = Scene()
+        >>> scene.apply_theme(THEME_STUDIO)
+        """
+        self.background.top_color = list(theme.background_top_color)
+        self.background.bottom_color = list(theme.background_bottom_color)
+        self.background._background_mode = theme.background_mode
+
+        self.grid._color = list(theme.grid_color)
+        self.grid._material.color = list(theme.grid_color)
+        self.grid._major_color = (
+            list(theme.grid_major_color) if theme.grid_major_color is not None else None
+        )
+        self.grid._major_interval = theme.grid_major_interval
+        # Rebuild grid geometry to reflect new colours
+        self.grid.resize(self.grid._xres, self.grid._yres)
+
+        if self.lights:
+            self.lights[0].position = list(theme.light_position)
+            self.lights[0].color = list(theme.light_color)
+
+    def theme_blender(self) -> None:
+        """Switch to the Blender-style neutral mid-gray viewport theme.
+
+        Example
+        -------
+        >>> scene = Scene()
+        >>> scene.theme_blender()
+        """
+        self.apply_theme(THEME_BLENDER)
+
+    def theme_studio(self) -> None:
+        """Switch to the Studio theme: warm charcoal background with vignette.
+
+        Example
+        -------
+        >>> scene = Scene()
+        >>> scene.theme_studio()
+        """
+        self.apply_theme(THEME_STUDIO)
+
+    def theme_gameengine(self) -> None:
+        """Switch to the Game-engine theme: sky-blue horizon with glow.
+
+        Example
+        -------
+        >>> scene = Scene()
+        >>> scene.theme_gameengine()
+        """
+        self.apply_theme(THEME_GAMEENGINE)
 
     def _step_physics(self, period: float, total: float) -> None:
         """Advance the physics simulation one step.
@@ -453,7 +544,9 @@ class Scene(Receiver):
         # Render background
         glViewport(0, 0, self.window_width, self.window_height)
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        self.background.render()
+        self.background.render(
+            self.window_width, self.window_height, self.active_camera
+        )
         glEnable(GL_DEPTH_TEST)
         glDepthFunc(GL_LESS)
 
@@ -901,6 +994,7 @@ class Background:
         self,
         top_color: Optional[Vector3D] = None,
         bottom_color: Optional[Vector3D] = None,
+        theme: Optional[SceneTheme] = None,
         **kwargs: Dict[str, Any],
     ):
         """Create a Background with optional top and bottom colors.
@@ -908,15 +1002,39 @@ class Background:
         Parameters
         ----------
         top_color : Vector3D or None
-            RGBA color for the top of the gradient. If None a default is used.
+            RGBA color for the top of the gradient.  When provided this
+            overrides any value from *theme*.
         bottom_color : Vector3D or None
-            RGBA color for the bottom of the gradient. If None a default is used.
+            RGBA color for the bottom of the gradient.  When provided this
+            overrides any value from *theme*.
+        theme : SceneTheme or None
+            Visual theme to initialise colors and background mode from.
+            Explicit *top_color* / *bottom_color* arguments take precedence.
         """
-        self.top_color = [0.0, 0.0, 0.0, 1.0] if top_color is None else top_color
-        self.bottom_color = (
-            [0.0, 0.1, 0.2, 1.0] if bottom_color is None else bottom_color
-        )
-        variables = ["top_color", "bot_color"]
+        if theme is not None:
+            self.top_color = list(theme.background_top_color)
+            self.bottom_color = list(theme.background_bottom_color)
+            self._background_mode: int = theme.background_mode
+        else:
+            self.top_color = [0.0, 0.0, 0.0, 1.0]
+            self.bottom_color = [0.0, 0.1, 0.2, 1.0]
+            self._background_mode = 0
+
+        # Explicit arguments override the theme
+        if top_color is not None:
+            self.top_color = list(top_color)
+        if bottom_color is not None:
+            self.bottom_color = list(bottom_color)
+
+        variables = [
+            "top_color",
+            "bot_color",
+            "time",
+            "resolution",
+            "background_mode",
+            "inv_proj",
+            "inv_view",
+        ]
         self._shader = Shader(
             fragment=background_fragment_shader,
             vertex=background_vertex_shader,
@@ -924,6 +1042,7 @@ class Background:
         )
         self._vao = None
         self.visible = True
+        self._start_time: float = time.time()
 
     def set_time(self, hour: int, minute: int) -> None:
         """Adjust the background gradient to approximate a time-of-day color.
@@ -986,11 +1105,25 @@ class Background:
                 ]
                 return
 
-    def render(self) -> None:
+    def render(
+        self, width: int = 0, height: int = 0, camera: Optional["Camera"] = None
+    ) -> None:
         """Render a full-screen gradient quad using the background shader.
 
         The method lazily builds the VAO and shader on first invocation. If
         the background is hidden the call is a no-op.
+
+        Parameters
+        ----------
+        width : int
+            Current viewport width in pixels (used for the *resolution*
+            shader uniform).
+        height : int
+            Current viewport height in pixels.
+        camera : Camera or None
+            Active camera. When provided and background_mode == 2 (game-engine),
+            the inverse projection and view matrices are passed to the shader so
+            the horizon glow follows the camera's actual look direction.
         """
         if not self.visible:
             return
@@ -1003,6 +1136,8 @@ class Background:
 
         glDisable(GL_DEPTH_TEST)
 
+        elapsed = time.time() - self._start_time
+
         self._shader.use()
         self._shader.set_vector4_np(
             "top_color", np.array(self.top_color, dtype=np.float32)
@@ -1010,6 +1145,19 @@ class Background:
         self._shader.set_vector4_np(
             "bot_color", np.array(self.bottom_color, dtype=np.float32)
         )
+        self._shader.set_float("time", elapsed)
+        self._shader.set_int("background_mode", self._background_mode)
+        if width > 0 and height > 0:
+            self._shader.set_resolution(float(width), float(height))
+
+        if self._background_mode == 2 and camera is not None:
+            proj, view = camera.render()
+            if proj is not None and view is not None:
+                inv_proj = np.asfortranarray(np.linalg.inv(proj), dtype=np.float32)
+                inv_view = np.asfortranarray(np.linalg.inv(view), dtype=np.float32)
+                self._shader.set_matrix4x4_np("inv_proj", inv_proj)
+                self._shader.set_matrix4x4_np("inv_view", inv_view)
+
         glBindVertexArray(self._vao)
         glDrawArrays(GL_TRIANGLES, 0, 3)
         glBindVertexArray(0)

--- a/payton/scene/shader.py
+++ b/payton/scene/shader.py
@@ -416,28 +416,58 @@ uniform vec4 top_color;
 uniform vec4 bot_color;
 uniform float time;
 uniform vec2 resolution;
-in vec2 v_uv;
 
+// 0 = clean gradient (Blender-style)
+// 1 = gradient + radial vignette (Studio)
+// 2 = gradient + camera-aware horizon glow (Game-engine)
+uniform int background_mode;
+
+// Camera matrices for world-space horizon reconstruction (mode 2)
+uniform mat4 inv_proj;
+uniform mat4 inv_view;
+
+in vec2 v_uv;
 out vec4 frag_color;
 
 void main()
 {
-    // Enhanced gradient with subtle animation
     float gradient_factor = smoothstep(0.0, 1.0, v_uv.y);
-    
-    // Add subtle color variation over time (optional)
+
+    // Subtle continuous colour oscillation (time wired up from Python)
     float time_variation = sin(time * 0.1) * 0.02 + 1.0;
-    
-    vec4 mixed_color = mix(bot_color, top_color, gradient_factor) * time_variation;
-    
-    // Add subtle noise for more natural look
-    float noise = fract(sin(dot(v_uv, vec2(12.9898, 78.233))) * 43758.5453) * 0.02 - 0.01;
-    mixed_color.rgb += noise;
-    
-    // Ensure colors stay in valid range
-    mixed_color = clamp(mixed_color, 0.0, 1.0);
-    
-    frag_color = mixed_color;
+
+    vec4 base = mix(bot_color, top_color, gradient_factor) * time_variation;
+
+    if (background_mode == 1) {
+        // --- Studio: radial vignette ---
+        vec2 center = v_uv - vec2(0.5, 0.5);
+        float vignette = 1.0 - dot(center, center) * 2.2;
+        vignette = clamp(vignette, 0.0, 1.0);
+        base.rgb *= vignette;
+
+    } else if (background_mode == 2) {
+        // --- Game-engine: camera-aware horizon glow ---
+        // Reconstruct view-space ray direction from NDC
+        vec4 ndc = vec4(v_uv * 2.0 - 1.0, 0.0, 1.0);
+        vec4 view_dir4 = inv_proj * ndc;
+        // Rotate to world space using only the camera's orientation (no translation)
+        vec3 world_dir = normalize(mat3(inv_view) * view_dir4.xyz);
+
+        // Horizon is where world_dir.z == 0 (Z-up system: ground plane is Z=0)
+        float horizon = 1.0 - abs(world_dir.z) * 4.5;
+        horizon = clamp(horizon, 0.0, 1.0);
+        horizon = pow(horizon, 2.0);
+        // Animate glow intensity slightly over time
+        float glow_strength = 0.28 + sin(time * 0.05) * 0.04;
+        vec3 glow = vec3(0.38, 0.52, 0.82) * horizon * glow_strength;
+        base.rgb += glow;
+    }
+
+    // Subtle noise to break up colour banding
+    float noise = fract(sin(dot(v_uv, vec2(12.9898, 78.233))) * 43758.5453) * 0.015 - 0.0075;
+    base.rgb += noise;
+
+    frag_color = clamp(base, 0.0, 1.0);
 }
 """  # type: str
 
@@ -493,6 +523,7 @@ class Shader:
             "far_plane",
             "time",
             "resolution",
+            "background_mode",
             "top_color",
             "bot_color",
             "particle_size",

--- a/payton/scene/shader.py
+++ b/payton/scene/shader.py
@@ -40,8 +40,11 @@ uniform vec3 light_pos[100];
 void main()
 {
     float lightDistance = length(FragPos.xyz - light_pos[0]);
-    lightDistance = lightDistance / far_plane;
-    gl_FragDepth = lightDistance;
+    // Push the stored depth slightly away from the light so that a surface
+    // does not shadow itself (polygon offset has no effect when gl_FragDepth
+    // is written manually, so the offset must be baked in here).
+    lightDistance += 0.08;
+    gl_FragDepth = lightDistance / far_plane;
 }
 """
 
@@ -238,30 +241,13 @@ vec3 gridSamplingDisk[20] = vec3[]
 float ShadowCalculation(vec3 fragPos)
 {
     if (LIGHT_COUNT == 0) return 0.0;
-    
+
     vec3 fragToLight = fragPos - light_pos[0];
     float currentDepth = length(fragToLight);
-    float shadow = 0.0;
-    
-    // Improved bias calculation
-    vec3 normal = normalize(l_normal);
-    vec3 lightDir = normalize(light_pos[0] - fragPos);
-    float bias = max(0.05 * (1.0 - dot(normal, lightDir)), 0.005);
-
-    float viewDistance = length(camera_pos - fragPos);
-    float diskRadius = (1.0 + (viewDistance / far_plane)) / 25.0;
-
-    int valid_samples = min(samples, 20);
-    for(int i = 0; i < valid_samples; ++i)
-    {
-        float closestDepth = texture(depthMap, fragToLight +
-                                     gridSamplingDisk[i] * diskRadius).r;
-        closestDepth *= far_plane;
-        if(currentDepth - bias > closestDepth)
-             shadow += 1.0;
-    }
-
-    return shadow / float(valid_samples);
+    // The depth map already has a world-space offset baked in at write time,
+    // so a straight compare is sufficient here.
+    float closestDepth = texture(depthMap, fragToLight).r * far_plane;
+    return currentDepth > closestDepth ? 1.0 : 0.0;
 }
 
 void main()
@@ -299,22 +285,20 @@ void main()
     
     // Check for invalid normals
     if (length(l_normal) < 0.1) {
-        FragColor = vec4(color * 0.5, alpha); // Fallback for invalid normals
+        FragColor = vec4(color, alpha);
         return;
     }
     
     vec3 viewDir = normalize(camera_pos - l_fragpos);
-    vec3 result = vec3(0.0);
+    vec3 result = 0.12 * color * ao;
     
     for (int i = 0; i < min(LIGHT_COUNT, 100); i++) {
-        vec3 lightDir = normalize(light_pos[i] - l_fragpos);
-        float distance = length(light_pos[i] - l_fragpos);
+        vec3 lightVector = light_pos[i] - l_fragpos;
+        float distance = length(lightVector);
+        vec3 lightDir = lightVector / max(distance, 0.0001);
         
-        // Enhanced attenuation
-        float attenuation = 1.0 / (1.0 + 0.045 * distance + 0.0075 * distance * distance);
-        
-        // Ambient
-        vec3 ambient = 0.15 * color * ao;
+        // Use a gentler falloff so the default scene scale doesn't look underlit.
+        float attenuation = 1.0 / (1.0 + 0.02 * distance + 0.001 * distance * distance);
         
         // Diffuse
         float diff = max(dot(norm, lightDir), 0.0);
@@ -322,8 +306,8 @@ void main()
         
         // Specular (Blinn-Phong)
         vec3 halfwayDir = normalize(lightDir + viewDir);
-        float spec_strength = mix(0.5, 1.0, metallic); // Use metallic to control specular strength
-        float shininess = mix(32.0, 128.0, 1.0 - roughness); // Use roughness to control shininess
+        float spec_strength = mix(0.35, 0.9, metallic);
+        float shininess = mix(32.0, 96.0, 1.0 - roughness);
         float spec = pow(max(dot(norm, halfwayDir), 0.0), shininess);
         vec3 specular = spec_strength * spec * light_color[i];
         
@@ -331,12 +315,14 @@ void main()
         float shadow = (i == 0 && shadow_enabled) ? ShadowCalculation(l_fragpos) : 0.0;
         
         // Combine results
-        vec3 lighting = ambient + (1.0 - shadow) * (diffuse + specular);
-        result += lighting * attenuation;
+        result += (1.0 - shadow) * (diffuse + specular) * attenuation;
     }
     
-    // Simple tone mapping
-    result = result / (result + vec3(1.0));
+    float peak = max(result.r, max(result.g, result.b));
+    if (peak > 1.0) {
+        result = result / (result + vec3(1.0));
+    }
+    result = clamp(result, 0.0, 1.0);
     
     // Gamma correction
     result = pow(result, vec3(1.0/2.2));

--- a/payton/scene/theme.py
+++ b/payton/scene/theme.py
@@ -1,0 +1,104 @@
+"""payton.scene.theme
+
+Scene visual themes for Payton.
+
+Three built-in presets are provided:
+
+* :data:`THEME_BLENDER`  – neutral mid-gray viewport
+* :data:`THEME_STUDIO`   – warm charcoal with vignette (default)
+* :data:`THEME_STUDIO`   – deep blue-black with vignette, warm key light
+* :data:`THEME_GAMEENGINE` – sky-blue gradient with horizon glow,
+  differentiated major/minor grid lines, warm sunlight
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class SceneTheme:
+    """Visual configuration applied to a :class:`~payton.scene.scene.Scene`.
+
+    All colour values are in linear RGB(A) space with components in [0, 1].
+
+    Attributes
+    ----------
+    background_top_color : list[float]
+        RGBA colour at the top of the background gradient.
+    background_bottom_color : list[float]
+        RGBA colour at the bottom of the background gradient.
+    background_mode : int
+        Shader rendering mode for the background:
+        ``0`` – clean smooth gradient (Blender-style),
+        ``1`` – gradient with radial vignette (Studio),
+        ``2`` – gradient with horizon glow band (Game-engine).
+    grid_color : list[float]
+        RGB colour for minor grid lines.
+    grid_major_color : list[float] or None
+        RGB colour for major grid lines.  ``None`` disables major-line
+        differentiation.
+    grid_major_interval : int
+        Every *n*-th grid line is drawn as a major line.
+    light_position : list[float]
+        Default XYZ position of the scene's first light.
+    light_color : list[float]
+        Default RGB colour of the scene's first light.
+    """
+
+    background_top_color: List[float] = field(
+        default_factory=lambda: [0.0, 0.0, 0.0, 1.0]
+    )
+    background_bottom_color: List[float] = field(
+        default_factory=lambda: [0.0, 0.1, 0.2, 1.0]
+    )
+    background_mode: int = 0
+    grid_color: List[float] = field(default_factory=lambda: [0.35, 0.35, 0.35])
+    grid_major_color: Optional[List[float]] = None
+    grid_major_interval: int = 5
+    light_position: List[float] = field(default_factory=lambda: [10.0, 7.0, 6.0])
+    light_color: List[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# Preset themes
+# ---------------------------------------------------------------------------
+
+THEME_BLENDER = SceneTheme(
+    # Mid-gray matching the Blender 4.x default viewport
+    background_top_color=[0.40, 0.40, 0.40, 1.0],
+    background_bottom_color=[0.30, 0.30, 0.30, 1.0],
+    background_mode=0,
+    grid_color=[0.50, 0.50, 0.50],
+    grid_major_color=[0.65, 0.65, 0.65],
+    grid_major_interval=5,
+    light_position=[7.5, 5.0, 5.0],
+    light_color=[1.0, 1.0, 1.0],
+)
+"""Neutral mid-gray viewport — matches the Blender 4.x default look."""
+
+THEME_STUDIO = SceneTheme(
+    # Warm charcoal — like a photography studio with a gradient sweep
+    background_top_color=[0.14, 0.14, 0.18, 1.0],
+    background_bottom_color=[0.22, 0.20, 0.25, 1.0],
+    background_mode=1,
+    grid_color=[0.28, 0.26, 0.32],
+    grid_major_color=[0.40, 0.38, 0.46],
+    grid_major_interval=5,
+    light_position=[10.0, 5.0, 8.0],
+    light_color=[1.0, 0.95, 0.85],
+)
+"""Warm charcoal background with a radial vignette and a warm key light."""
+
+THEME_GAMEENGINE = SceneTheme(
+    # Bright sky-blue horizon — reminiscent of Unreal / Unity editor
+    background_top_color=[0.38, 0.55, 0.78, 1.0],
+    background_bottom_color=[0.18, 0.28, 0.48, 1.0],
+    background_mode=2,
+    grid_color=[0.32, 0.38, 0.50],
+    grid_major_color=[0.50, 0.58, 0.72],
+    grid_major_interval=5,
+    light_position=[15.0, 10.0, 12.0],
+    light_color=[1.0, 0.97, 0.88],
+)
+"""Sky-blue gradient with a horizon glow, differentiated grid lines and
+warm sunlight — reminiscent of Unreal Engine / Unity editor viewports."""

--- a/payton/tools/mesh/geometry.py
+++ b/payton/tools/mesh/geometry.py
@@ -1,11 +1,70 @@
 from copy import deepcopy
+from typing import Dict, List, Tuple
 
-from payton.math.functions import distance, mid_point
+from payton.math.functions import add_vectors, mid_point, normalize_vector, vector_norm
 from payton.scene.geometry import Mesh
+from payton.scene.material import DEFAULT
+
+
+def _smooth_normals(mesh: Mesh, precision: int = 5) -> None:
+    """Recompute smooth normals for *mesh* in-place.
+
+    Each face's geometric normal is accumulated into every vertex that shares
+    the same 3-D position (within *precision* decimal places).  The result is
+    angle-weighted smooth normals with no T-junction or interpolation artefacts.
+
+    Vertices whose accumulated normals cancel to zero (e.g. on a hard seam)
+    fall back to their original flat face normal so no vertex is left dark.
+
+    Keyword arguments:
+    mesh      -- Mesh to update (modified in place)
+    precision -- Decimal places used when comparing vertex positions
+    """
+    # Map rounded position tuple → list of vertex indices at that position
+    pos_to_indices: Dict[Tuple, List[int]] = {}
+    for idx, v in enumerate(mesh._vertices):
+        key = tuple(round(c, precision) for c in v)
+        pos_to_indices.setdefault(key, []).append(idx)
+
+    # Accumulate face normals into each vertex bucket
+    accumulated: List[List[float]] = [[0.0, 0.0, 0.0] for _ in mesh._vertices]
+    for face in mesh._indices:
+        i0, i1, i2 = face[0], face[1], face[2]
+        fn = mesh._normals[i0]  # flat normal already set by add_triangle
+        for fi in (i0, i1, i2):
+            key = tuple(round(c, precision) for c in mesh._vertices[fi])
+            for shared_idx in pos_to_indices[key]:
+                accumulated[shared_idx] = add_vectors(accumulated[shared_idx], fn)
+
+    # Normalise and write back; fall back to existing flat normal on cancellation
+    for idx, acc in enumerate(accumulated):
+        if vector_norm(acc) > 1e-8:
+            mesh._normals[idx] = normalize_vector(acc)
+        # else: keep the flat face normal already stored by add_triangle
+
+
+def _material_indices(mesh: Mesh) -> dict:
+    """Return per-material face index lists for *mesh*.
+
+    If all materials have empty ``_indices`` (e.g. the user replaced the
+    material object via ``mesh.material = m`` which discards the original
+    indices), fall back to assigning all faces in ``mesh._indices`` to the
+    DEFAULT material.
+    """
+    total_in_mats = sum(len(m._indices) for m in mesh.materials.values())
+    if total_in_mats == 0 and mesh._indices:
+        # Material was replaced and indices are only on the mesh — reassign
+        result: Dict[str, List] = {name: [] for name in mesh.materials}
+        result[DEFAULT] = list(mesh._indices)
+        return result
+    return {name: list(mat._indices) for name, mat in mesh.materials.items()}
 
 
 def merge_mesh(mesh1: Mesh, mesh2: Mesh) -> Mesh:
-    """Merge two meshes into a single mesh
+    """Merge two meshes into a single mesh.
+
+    Materials from both meshes are preserved. mesh2 materials that share a name
+    with mesh1 materials will be suffixed with '_2'.
 
     Keyword arguments:
     mesh1 -- First mesh
@@ -14,84 +73,97 @@ def merge_mesh(mesh1: Mesh, mesh2: Mesh) -> Mesh:
     m1_vertices = list(mesh1.absolute_vertices())
     m2_vertices = list(mesh2.absolute_vertices())
     mesh = Mesh()
-    mesh.material = deepcopy(mesh1.material)
     mesh._vertices = m1_vertices + m2_vertices
     mesh._vertex_colors = mesh1._vertex_colors + mesh2._vertex_colors
     mesh._vertex_count = len(mesh._vertices)
     mesh._texcoords = mesh1._texcoords + mesh2._texcoords
     mesh._normals = mesh1._normals + mesh2._normals
     len_v = len(mesh1._vertices)
-    m2_indices = [[i[0] + len_v, i[1] + len_v, i[2] + len_v] for i in mesh2._indices]
-    mesh._indices = mesh1._indices + m2_indices
-    mesh.material._indices = mesh._indices
+
+    m1_idx = _material_indices(mesh1)
+    m2_idx = _material_indices(mesh2)
+
+    # Copy mesh1 materials with their resolved indices
+    for name, mat in mesh1.materials.items():
+        new_mat = deepcopy(mat)
+        new_mat._indices = m1_idx.get(name, [])
+        mesh.materials[name] = new_mat
+
+    # Offset and copy mesh2 indices into their respective materials
+    for name, mat in mesh2.materials.items():
+        m2_material_indices = [
+            [i[0] + len_v, i[1] + len_v, i[2] + len_v] for i in m2_idx.get(name, [])
+        ]
+        target_name = name if name not in mesh.materials else f"{name}_2"
+        new_mat = deepcopy(mat)
+        new_mat._indices = m2_material_indices
+        mesh.materials[target_name] = new_mat
+
+    # Rebuild the flat index list from all materials
+    all_indices = []
+    for mat in mesh.materials.values():
+        all_indices.extend(mat._indices)
+    mesh._indices = all_indices
+
     mesh._calc_bounds()
     mesh.refresh()
     return mesh
 
 
-def subdivide(original: Mesh) -> Mesh:
-    """Subdivide the mesh polygons by given steps
+def subdivide(original: Mesh, smooth: bool = True) -> Mesh:
+    """Subdivide the mesh by splitting each triangle into 4 sub-triangles.
+
+    Each triangle is subdivided by inserting a midpoint on every edge, yielding
+    four congruent child triangles.  Because **all three** edges are always
+    split, adjacent triangles will always agree on the edge midpoint — there
+    are no T-junctions and the topology is consistent.
+
+    After splitting, face normals are recomputed from the actual geometry and
+    then smoothed by averaging across faces that share the same vertex position
+    (see *smooth* argument).
 
     Keyword arguments:
-    mesh -- Original mesh
+    original -- Original mesh to subdivide
+    smooth   -- When True (default) compute smooth normals; when False keep
+                flat per-face normals
     """
     new = Mesh()
     has_texcoords = len(original._texcoords) == len(original._vertices)
     new.clear_triangles()
 
     for indice in original._indices:
-        v1 = original._vertices[indice[0]]
-        v2 = original._vertices[indice[1]]
-        v3 = original._vertices[indice[2]]
+        i0, i1, i2 = indice[0], indice[1], indice[2]
 
-        a = v1
-        a_i = indice[0]
-        b = v2
-        b_i = indice[1]
-        c = v3
-        c_i = indice[2]
+        v0 = original._vertices[i0]
+        v1 = original._vertices[i1]
+        v2 = original._vertices[i2]
 
-        if distance(v2, v3) > distance(v1, v2):
-            a = v2
-            a_i = indice[1]
-            b = v3
-            b_i = indice[2]
-            c = v1
-            c_i = indice[0]
+        # Midpoints on every edge — guarantees no T-junctions
+        m01 = mid_point(v0, v1)
+        m12 = mid_point(v1, v2)
+        m20 = mid_point(v2, v0)
 
-        if distance(v3, v1) > distance(v2, v3):
-            a = v3
-            a_i = indice[2]
-            b = v1
-            b_i = indice[0]
-            c = v2
-            c_i = indice[1]
-
-        vc = mid_point(a, b)
-        n1 = original._normals[indice[0]]
-        texcoords_1 = None
-        texcoords_2 = None
+        # Four child triangles (CCW winding matches parent).
+        # Normals are omitted — add_triangle computes the correct flat
+        # face normal automatically; _smooth_normals refines them afterwards.
         if has_texcoords:
-            t1 = original._texcoords[a_i]
-            t2 = original._texcoords[b_i]
-            t3 = original._texcoords[c_i]
-            t1.append(0)
-            t2.append(0)
-            t3.append(0)
+            tc0: List[float] = list(original._texcoords[i0])
+            tc1: List[float] = list(original._texcoords[i1])
+            tc2: List[float] = list(original._texcoords[i2])
+            tc01: List[float] = [(tc0[0] + tc1[0]) / 2.0, (tc0[1] + tc1[1]) / 2.0]
+            tc12: List[float] = [(tc1[0] + tc2[0]) / 2.0, (tc1[1] + tc2[1]) / 2.0]
+            tc20: List[float] = [(tc2[0] + tc0[0]) / 2.0, (tc2[1] + tc0[1]) / 2.0]
+            new.add_triangle(vertices=[v0, m01, m20], texcoords=[tc0, tc01, tc20])
+            new.add_triangle(vertices=[m01, v1, m12], texcoords=[tc01, tc1, tc12])
+            new.add_triangle(vertices=[m20, m12, v2], texcoords=[tc20, tc12, tc2])
+            new.add_triangle(vertices=[m01, m12, m20], texcoords=[tc01, tc12, tc20])
+        else:
+            new.add_triangle(vertices=[v0, m01, m20])
+            new.add_triangle(vertices=[m01, v1, m12])
+            new.add_triangle(vertices=[m20, m12, v2])
+            new.add_triangle(vertices=[m01, m12, m20])
 
-            tc = mid_point(t1, t2)
+    if smooth:
+        _smooth_normals(new)
 
-            texcoords_1 = [t1[:2], tc[:2], t3[:2]]
-            texcoords_2 = [t3[:2], tc[:2], t2[:2]]
-
-        new.add_triangle(
-            vertices=[a, vc, c],
-            normals=[n1, n1, n1],
-            texcoords=texcoords_1,
-        )
-        new.add_triangle(
-            vertices=[c, vc, b],
-            normals=[n1, n1, n1],
-            texcoords=texcoords_2,
-        )
     return new

--- a/payton/tools/mesh/line.py
+++ b/payton/tools/mesh/line.py
@@ -2,7 +2,12 @@
 
 from typing import List
 
-from payton.math.functions import add_vectors, create_rotation_matrix_raw, scale_vector, vector_transform
+from payton.math.functions import (
+    add_vectors,
+    create_rotation_matrix_raw,
+    scale_vector,
+    vector_transform,
+)
 from payton.math.vector import Vector3D
 from payton.scene.geometry import Line, Mesh
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a theme-aware visual system for scenes and UI, overhaul mesh subdivision/merging and lighting behavior, and add a new interactive 3D designer example with scene save/export support.

New Features:
- Add SceneTheme system with Blender, Studio, and Game-engine presets and expose them via the public scene API.
- Allow Scene to be constructed with a theme, derive a matching UI theme, and provide helper methods to switch themes at runtime.
- Add camera-aware, mode-based background rendering with animated gradients, vignette, and horizon glow options.
- Introduce major/minor grid line support with configurable colors and intervals.
- Add a 3D object designer example app with UI panels to create/edit primitives, plus JSON scene save/load and OBJ export utilities.

Bug Fixes:
- Fix Mesh.add_triangle indices to use the current vertex count instead of the face count.
- Ensure mesh normals are stored as independent lists and initialize them per-vertex to avoid shared-state artifacts.
- Guard automatic UV generation against zero-size bounding boxes to avoid division-by-zero on flat meshes.
- Correct NO_INDICE handling in mesh material VAO creation so buffers are allocated once indices exist.
- Clamp vector_angle dot product to [-1,1] to avoid math domain errors from floating-point drift.
- Fix HUD click propagation to return the actual clicked mesh and improve default font initialization fallback for Text widgets.
- Adjust background render calls and shaders to accept resolution, time, and camera data without breaking when not available.

Enhancements:
- Update GUI window theme to a modern dark-editor palette with configurable borders, highlights, and a reusable Theme.from_scene_theme helper.
- Refine window, panel, and button geometry (title bar height, borders, separators, bevels) and improve button label placement using accurate font metrics via Pillow.
- Improve mesh merging to preserve per-material indices from both meshes and handle cases where material indices were reset.
- Rewrite mesh subdivision to perform consistent 4-way midpoint splits, optionally recompute smooth normals, and provide an internal helper to rebuild smooth vertex normals.
- Adjust lighting and shadow shaders for more stable shadow mapping and more natural attenuation, specular response, and tonemapping.
- Refine grid default color and rendering to separate axis, minor, and major lines and rebuild them cleanly on resize.
- Tweak help window layout and text rendering for better readability.

Build:
- Simplify formatting workflow by dropping the isort step from the Makefile in favor of ruff-only formatting.

Documentation:
- Extend the main README with a link to the new 3D object designer example.
- Add dedicated README documentation for the designer example explaining usage, controls, and file formats.